### PR TITLE
set version 2.7.2 for maven-surefire-plugin to suppress warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <maven.jxr.plugin.version>2.3</maven.jxr.plugin.version>
     <maven.reports.version>2.2</maven.reports.version>
     <maven.site.version>3.0-beta-3</maven.site.version>
+    <maven.surefire.version>2.7.2</maven.surefire.version>
 
     <jackson-version>1.8.6</jackson-version>
 
@@ -177,6 +178,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven.surefire.version}</version>
         <configuration>
           <argLine>-Xmx1024m</argLine>
           <systemProperties>


### PR DESCRIPTION
Hi Alex,

I'm one of the reviewers for Manning.  I worked with the code from GitHub at this revision:

commit 002b87838d1ecd1e1a8d02d360f64ea27e34fc59
Date:   Sat Feb 18 21:34:07 2012 -0500

When I ran “mvn package”, I got this warning:

[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.manning.hip:hadoop-book:jar:1.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ line 177, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 

I’m on a MacBook Pro running OS X 10.6.8, Java 1.6.0_29 64-bit and Maven 3.0.3.  This pull request fixes it by explicitly setting maven-surefire-plugin version 2.7.2, which is the same version in effect reported by "mvn help:effective-pom".

I'm really enjoying the book!

Thanks,
--Chris
